### PR TITLE
Small update

### DIFF
--- a/lessons/misc-quick-reference/slack.md
+++ b/lessons/misc-quick-reference/slack.md
@@ -19,7 +19,7 @@ Hi there, is this code correct: `var answer = 42;` or do I need to do something 
 This will format the snippet `var answer = 42;` in a stylized manner directly in
 your message!
 
-If you have a longer block you can enclose it in three backtick (`) characters
+If you have a longer block you can enclose it in three backtick (\`) characters
 like this:
 
 ````

--- a/lessons/misc-quick-reference/slack.md
+++ b/lessons/misc-quick-reference/slack.md
@@ -19,7 +19,7 @@ Hi there, is this code correct: `var answer = 42;` or do I need to do something 
 This will format the snippet `var answer = 42;` in a stylized manner directly in
 your message!
 
-If you have a longer block you can enclose it in three backtick (\\`) characters
+If you have a longer block you can enclose it in three backtick (`) characters
 like this:
 
 ````


### PR DESCRIPTION
Not sure how the formatting is exactly supposed to be. In the handbook there was a \ in front of the backtick