### PR TITLE
Update one-list.md

### DIFF
--- a/lessons/misc-api-intro/one-list.md
+++ b/lessons/misc-api-intro/one-list.md
@@ -241,6 +241,6 @@ Here are some common HTTP response codes you are likely to see
 
 ## Sites to look up response codes
 
-- [HTTP Status Dogs](https://httpstatusdogs.com/)
-- [Text HTTP Status](https://httpstatuses.com/)
-- [HTTP Status Cats](https://www.flickr.com/photos/girliemac/albums/72157628409467125/)
+- [HTTP Status Dogs](https://http.dog/)
+- [Text HTTP Status](https://http.dev/status)
+- [HTTP Status Cats](https://httpcats.com/)


### PR DESCRIPTION
httpstatuses.com does not exist anymore. dogs and cats URLs updated to sites supporting more status codes.